### PR TITLE
Refactor Serializers and API Views into separate files

### DIFF
--- a/mendel/api_views.py
+++ b/mendel/api_views.py
@@ -1,0 +1,36 @@
+from .models import Keyword, Category, Document, Context, Review, User
+from .serializers import CategorySerializer, ContextSerializer, DocumentSerializer, KeywordSerializer, ReviewSerializer, UserSerializer, TokenSerializer
+
+from rest_framework import permissions, serializers, viewsets
+
+
+# API Views
+class KeywordViewSet(viewsets.ModelViewSet):
+    queryset = Keyword.objects.all()
+    serializer_class = KeywordSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+
+class CategoryViewSet(viewsets.ModelViewSet):
+    queryset = Category.objects.all()
+    serializer_class = CategorySerializer
+    permission_classes = (permissions.IsAuthenticated,)
+
+class ContextViewSet(viewsets.ModelViewSet):
+    queryset = Context.objects.all()
+    serializer_class = ContextSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+
+class DocumentViewSet(viewsets.ModelViewSet):
+    queryset = Document.objects.all()
+    serializer_class = DocumentSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+
+class ReviewViewSet(viewsets.ModelViewSet):
+    queryset = Review.objects.all()
+    serializer_class = ReviewSerializer
+    permission_classes = (permissions.IsAuthenticated,)
+
+class UserViewSet(viewsets.ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+    permission_classes = (permissions.IsAdminUser,)

--- a/mendel/serializers.py
+++ b/mendel/serializers.py
@@ -1,0 +1,72 @@
+from .models import Keyword, Category, Document, Context, Review, User
+
+from rest_auth.models import TokenModel
+from rest_framework import serializers
+
+
+# Keyword
+class KeywordSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Keyword
+        fields = ('id', 'name', 'definition')
+
+    def create(self, validated_data):
+        instance, _ = Keyword.objects.get_or_create(**validated_data)
+        return instance
+
+# Category
+class CategorySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Category
+        fields = ('id', 'name', 'description')
+
+# Context
+class ContextSerializer(serializers.ModelSerializer):
+    keyword_given = KeywordSerializer()
+
+    class Meta:
+        model = Context
+        fields = ('id', 'position_from', 'position_to', 'text', 'document', 'keyword_given', 'next_context_id', 'prev_context_id', 'reviews')
+        depth = 1
+
+    # return the object
+    # def reviews(self, user):
+    #     try:
+    #         return Review.objects.filter(user=request.user.id)
+    #     except:
+    #         return None
+
+# Document
+class DocumentSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Document
+        fields = ('__all__')
+
+# Review
+class ReviewSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Review
+        fields = ('__all__')
+
+# User
+class UserSerializer(serializers.ModelSerializer):
+    last_context_id = serializers.SerializerMethodField('return_last_context_id')
+
+    def return_last_context_id(self, user):
+        try:
+            return Review.objects.filter(user=user.id).latest('created').context.id
+        except:
+            return Context.objects.first().id
+
+    class Meta:
+        model = User
+        fields = ('id', 'username', 'is_staff', 'last_context_id')
+
+# Token (Django REST Auth)
+class TokenSerializer(serializers.ModelSerializer):
+    user = UserSerializer()
+
+    class Meta:
+        model = TokenModel
+        fields = ('key','user',)
+        depth = 1

--- a/settings.py
+++ b/settings.py
@@ -171,8 +171,8 @@ REST_FRAMEWORK = {
 
 # REST Auth
 REST_AUTH_SERIALIZERS = {
-    'TOKEN_SERIALIZER': 'urls.TokenSerializer',
-    'USER_DETAILS_SERIALIZER': 'urls.UserSerializer',
+    'TOKEN_SERIALIZER': 'mendel.api_views.TokenSerializer',
+    'USER_DETAILS_SERIALIZER': 'mendel.api_views.UserSerializer',
 }
 
 # you'll need to register for a Wordnik api key for definitions to work on the keyword

--- a/urls.py
+++ b/urls.py
@@ -5,107 +5,19 @@ from django.contrib import admin
 admin.autodiscover()
 
 import mendel.views
-from mendel.models import Keyword, Category, Document, Context, Review
-from django.contrib.auth.models import User
-from rest_auth.models import TokenModel
-from rest_framework import permissions, routers, serializers, viewsets
+from mendel.api_views import KeywordViewSet, CategoryViewSet, ContextViewSet, DocumentViewSet, ReviewViewSet, UserViewSet
 
+from rest_framework import routers
 
-class KeywordSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Keyword
-        fields = ('id', 'name', 'definition')
-
-class KeyViewSet(viewsets.ModelViewSet):
-    queryset = Keyword.objects.all()
-    serializer_class = KeywordSerializer
-    permission_classes = (permissions.IsAuthenticated,)
-
-class CategorySerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Category
-        fields = ('id', 'name', 'description')
-
-class CategoryViewSet(viewsets.ModelViewSet):
-    queryset = Category.objects.all()
-    serializer_class = CategorySerializer
-    permission_classes = (permissions.IsAuthenticated,)
-
-class ContextSerializer(serializers.ModelSerializer):
-    keyword_given = KeywordSerializer()
-
-    class Meta:
-        model = Context
-        fields = ('id', 'position_from', 'position_to', 'text', 'document', 'keyword_given', 'next_context_id', 'prev_context_id', 'reviews')
-        depth = 1
-
-    # return the object
-    # def reviews(self, user):
-    #     try:
-    #         return Review.objects.filter(user=request.user.id)
-    #     except:
-    #         return None
-
-class ContextViewSet(viewsets.ModelViewSet):
-    queryset = Context.objects.all()
-    serializer_class = ContextSerializer
-    permission_classes = (permissions.IsAuthenticated,)
-
-class DocumentSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Document
-        fields = ('__all__')
-
-class DocumentViewSet(viewsets.ModelViewSet):
-    queryset = Document.objects.all()
-    serializer_class = DocumentSerializer
-    permission_classes = (permissions.IsAuthenticated,)
-
-class ReviewSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Review
-        fields = ('__all__')
-
-class ReviewViewSet(viewsets.ModelViewSet):
-    queryset = Review.objects.all()
-    serializer_class = ReviewSerializer
-    permission_classes = (permissions.IsAuthenticated,)
-
-class UserSerializer(serializers.ModelSerializer):
-    last_context_id = serializers.SerializerMethodField('return_last_context_id')
-
-    def return_last_context_id(self, user):
-        try:
-            return Review.objects.filter(user=user.id).latest('created').context.id
-        except:
-            return Context.objects.first().id
-
-
-    class Meta:
-        model = User
-        fields = ('id', 'username', 'is_staff', 'last_context_id')
-
-class UserViewSet(viewsets.ModelViewSet):
-    queryset = User.objects.all()
-    serializer_class = UserSerializer
-    permission_classes = (permissions.IsAdminUser,)
-
-# Django Rest Auth Token Serializer
-class TokenSerializer(serializers.ModelSerializer):
-    user = UserSerializer()
-
-    class Meta:
-        model = TokenModel
-        fields = ('key','user',)
-        depth = 1
 
 router = routers.DefaultRouter()
-router.register(r'keywords', KeyViewSet)
+router.register(r'keywords', KeywordViewSet)
 router.register(r'categories', CategoryViewSet)
 router.register(r'documents', DocumentViewSet)
 router.register(r'context', ContextViewSet)
 router.register(r'reviews', ReviewViewSet)
 router.register(r'users', UserViewSet)
+
 
 urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),


### PR DESCRIPTION
Previously, serializers and API viewsets lived in the `urls.py` file. 

This pull request will separate these pieces into their own files:
- `mendel/api_views.py`
- `mendel/serializers.py`

cc: @seanauriti
