### PR TITLE
Edit keywords feature (#30)

### DIFF
--- a/mendel/angular/src/app/app.module.js
+++ b/mendel/angular/src/app/app.module.js
@@ -13,6 +13,7 @@
       'ngResource',
       'ngSanitize',
       'ngStorage',
+      'focus-if',
       'toastr',
       'ui.router',
     ]);

--- a/mendel/angular/src/app/main/main.controller.js
+++ b/mendel/angular/src/app/main/main.controller.js
@@ -347,6 +347,11 @@
         }
       });
 
+      // Save keyword (in case user is editing keyword when they go to next context)
+      if (vm.editingKeyword) {
+        saveKeyword();
+      }
+
       // Submit Reviews
       Context.submitReviews({
         id: vm.context.id,

--- a/mendel/angular/src/app/main/main.controller.js
+++ b/mendel/angular/src/app/main/main.controller.js
@@ -90,6 +90,21 @@
     // Get Context
     function getContext (id) {
 
+      // If no ID is passed in, create an "empty" context
+      if (!id) {
+
+        // Set previous context ID from last context
+        var _prevContextId = angular.copy(vm.context.id);
+
+        // Empty Context
+        vm.context = {};
+        vm.keyword = null;
+        vm.context.prev_context_id = _prevContextId;
+
+        return;
+      }
+
+      // Get context
       Context.get({id: id})
       .$promise
       .then(getContextSuccess)
@@ -190,7 +205,6 @@
 
         // Resolve the promise with the categories
         return deferred.resolve(categories);
-
       }
 
       function getCategoriesError (error) {
@@ -232,7 +246,8 @@
 
       var _nextContextId = vm.context.next_context_id;
 
-      if (_nextContextId) {
+      // Check if the current context is not empty
+      if (vm.context.id) {
 
         submitReviews()
         .then(function (success) {
@@ -266,10 +281,8 @@
 
       var _prevContextId = vm.context.prev_context_id;
 
-      if (_prevContextId) {
-  
-        // Deselect all categories
-        deselectAllCategories();
+      // Check if the current context is not empty
+      if (vm.context.id) {
 
         submitReviews()
         .then(function (success) {

--- a/mendel/angular/src/app/main/main.controller.js
+++ b/mendel/angular/src/app/main/main.controller.js
@@ -120,9 +120,31 @@
           var _prevCategories = [];
 
           // Load previously-selected categories
-          angular.forEach(context.user_reviews, function(review){
+          angular.forEach(context.user_reviews, function(review) {
+
+            // Check if this context has reviews with a different keyword_proposed
+            if (review.keyword_given !== review.keyword_proposed) {
+
+              // Get the proposed keyword from API
+              Keyword.get({id: review.keyword_proposed})
+              .$promise
+              .then(setUpdatedKeywordSuccess)
+              .catch(setUpdatedKeywordError);
+            }
+
+            // Push this category to previously-selected categories
             _prevCategories.push(review.category);
           });
+
+          // Callbacks for setting updated keyword from keyword_proposed
+          function setUpdatedKeywordSuccess (keyword_proposed) {
+            vm.keyword = keyword_proposed;
+          }
+
+          function setUpdatedKeywordError (error) {
+            toastr.error('Could not get this context. Check the browser console for more information.', 'Error');
+            console.error(error);
+          }
 
           // Loop through categories, set "selected" if in prevously selected categories for context
           angular.forEach(vm.categories, function(category) {

--- a/mendel/angular/src/app/main/main.controller.js
+++ b/mendel/angular/src/app/main/main.controller.js
@@ -210,38 +210,7 @@
 
       vm.editingKeyword = false;
 
-      // If we haven't changed the keyword, don't bother saving
-      if (vm.newKeyword.name === vm.keyword.name) {
-        return;
-      }
-
-      // POST to the Keywords endpoint to get_or_create the Keyword
-      Keyword.save({
-        name: vm.newKeyword.name
-      })
-      .$promise
-      .then(saveKeywordSuccess)
-      .catch(saveKeywordError);
-
-      function saveKeywordSuccess (data) {
-
-        // Set flag for when user goes to next context
-        vm.updatedKeyword = true;
-
-        // Reset vm.keyword
-        vm.keyword = data;
-      }
-
-      function saveKeywordError (error) {
-
-        // Reset Keyword to Context's Original Keyword
-        vm.keyword = vm.context.keyword_given;
-
-        // Show Error Toast
-        for (var i in error.data) {
-          toastr.error(JSON.stringify(error.data[i]), 'Error', {timeOut: 5000});
-        }
-      }
+      vm.keyword = vm.newKeyword;
     }
 
     // Get Next Context

--- a/mendel/angular/src/app/main/main.controller.js
+++ b/mendel/angular/src/app/main/main.controller.js
@@ -12,7 +12,8 @@
     vm.getNextContext = getNextContext;
     vm.getPrevContext = getPrevContext;
     vm.toggleSpecialCategory = toggleSpecialCategory;
-
+    vm.editKeyword = editKeyword;
+    vm.saveKeyword = saveKeyword;
 
     // Initialize
     init();
@@ -79,7 +80,6 @@
       })
       ;
     }
-
 
     // Controller Functions
 
@@ -196,6 +196,56 @@
       }
     }
 
+    // Edit Keyword
+    function editKeyword () {
+
+      vm.editingKeyword = true;
+
+      vm.newKeyword = {
+        name: vm.keyword.name
+      };
+
+    }
+
+    // Save New Keyword
+    function saveKeyword () {
+
+      vm.editingKeyword = false;
+
+      // If we haven't changed the keyword, don't bother saving
+      if (vm.newKeyword.name === vm.keyword.name) {
+        return;
+      }
+
+      // POST to the Keywords endpoint to get_or_create the Keyword
+      Keyword.save({
+        name: vm.newKeyword.name
+      })
+      .$promise
+      .then(saveKeywordSuccess)
+      .catch(saveKeywordError);
+
+      function saveKeywordSuccess (data) {
+
+        // Set flag for when user goes to next context
+        vm.updatedKeyword = true;
+
+        // Reset vm.keyword
+        vm.keyword = data;
+      }
+
+      function saveKeywordError (error) {
+
+        // Reset Keyword to Context's Original Keyword
+        vm.keyword = vm.context.keyword;
+
+        // Show Error Toast
+        for (var i in error.data) {
+          toastr.error(JSON.stringify(error.data[i]), 'Error', {timeOut: 5000});
+        }
+      }
+    }
+
     // Get Next Context
     function getNextContext () {
 
@@ -275,6 +325,13 @@
 
     // Submit Reviews
     function submitReviews () {
+
+      /*
+        Check if user has changed keyword
+        - if yes:
+          - unselect any previously selected keywords
+          - reselect any previously-selected categories from this context
+      */
 
       // Set up deferred object to return
       var deferred = $q.defer();

--- a/mendel/angular/src/app/main/main.controller.js
+++ b/mendel/angular/src/app/main/main.controller.js
@@ -6,7 +6,7 @@
     .controller('MainController', MainController);
 
   /** @ngInject */
-  function MainController($q, $scope, AuthService, Category, Context, hotkeys, Review, Session, toastr) {
+  function MainController($q, $scope, AuthService, Category, Context, hotkeys, Keyword, Review, Session, toastr) {
     var vm = this;
 
     vm.getNextContext = getNextContext;
@@ -96,7 +96,7 @@
         vm.context = context;
         vm.context.front = '"...' + vm.context.text.substring(0, vm.context.position_from);
         vm.context.back = vm.context.text.substring(vm.context.position_to, vm.context.text.length) + '..."';
-        vm.keyword = context.keyword_given;
+        vm.keyword = angular.copy(context.keyword_given);
         vm.context.previouslySelectedCategories = preselect();
 
         function preselect () {
@@ -237,7 +237,7 @@
       function saveKeywordError (error) {
 
         // Reset Keyword to Context's Original Keyword
-        vm.keyword = vm.context.keyword;
+        vm.keyword = vm.context.keyword_given;
 
         // Show Error Toast
         for (var i in error.data) {
@@ -419,18 +419,7 @@
           category: categoryId,
           context: vm.context.id,
           keyword_given: vm.context.keyword_given.id,
-
-          /* 
-            Note re: keyword_proposed field:
-
-            keyword_proposed is hardcoded as the same value as keyword_given
-            until we build the "Edit Keyword" feature
-          */
-
-          keyword_proposed: vm.context.keyword_given.id,
-
-          //
-
+          keyword_proposed: vm.keyword.id,
           user: Session.user.id
         };
 

--- a/mendel/angular/src/app/main/main.html
+++ b/mendel/angular/src/app/main/main.html
@@ -58,7 +58,11 @@
       <div class="callout small-12 columns with-bottom-margin">
 
         <!-- Keyword -->
-        <h1 ng-hide="main.editingKeyword">{{ main.keyword.name }}</h1>
+        <h1 ng-hide="main.editingKeyword">
+          {{ main.keyword.name }}
+          <!-- "Edited" label -->
+          <small ng-show="main.keyword.name !== main.context.keyword_given.name">(edited)</small>
+        </h1>
 
         <!-- Edit Keyword -->
         <form ng-show="main.editingKeyword" ng-submit="main.saveKeyword()">

--- a/mendel/angular/src/app/main/main.html
+++ b/mendel/angular/src/app/main/main.html
@@ -11,7 +11,7 @@
     </div>
 
     <!-- Right Side -->
-    <div ng-show="main.context.keyword_given" class="column align-right expand text-right">
+    <div ng-show="main.context.id" class="column align-right expand text-right">
 
       <!-- Special Categories -->
       <div class="special-categories">

--- a/mendel/angular/src/app/main/main.html
+++ b/mendel/angular/src/app/main/main.html
@@ -62,7 +62,7 @@
 
         <!-- Edit Keyword -->
         <form ng-show="main.editingKeyword" ng-submit="main.saveKeyword()">
-          <input class="edit-keyword" focus-if="main.editingKeyword" ng-model="main.newKeyword.name"></input>
+          <input class="edit-keyword" focus-if="main.editingKeyword" ng-model="main.newKeyword.name" ng-blur="main.saveKeyword()"></input>
         </form>
 
         <!-- Edit Keyword Link -->

--- a/mendel/angular/src/app/main/main.html
+++ b/mendel/angular/src/app/main/main.html
@@ -6,12 +6,12 @@
     <div class="column align-left shrink">
 
       <!-- "Prev" Link -->
-      <a ng-click="main.getPrevContext()"><i class="material-icons">arrow_back</i> Prev</a>
+      <a ng-show="main.context.prev_context_id" ng-click="main.getPrevContext()"><i class="material-icons">arrow_back</i> Prev</a>
 
     </div>
 
     <!-- Right Side -->
-    <div class="column align-right expand text-right">
+    <div ng-show="main.context.keyword_given" class="column align-right expand text-right">
 
       <!-- Special Categories -->
       <div class="special-categories">

--- a/mendel/angular/src/app/main/main.html
+++ b/mendel/angular/src/app/main/main.html
@@ -54,10 +54,23 @@
       <!-- Subject Header -->
       <h2 class="subheader">Subject</h2>
 
-      <!-- Word Panel -->
+      <!-- Keyword Panel -->
       <div class="callout small-12 columns with-bottom-margin">
-        <h1>{{ main.keyword.name }}</h1>
-        <p class="subheader"><a ng-href="#">Edit keyword</a></p>
+
+        <!-- Keyword -->
+        <h1 ng-hide="main.editingKeyword">{{ main.keyword.name }}</h1>
+
+        <!-- Edit Keyword -->
+        <form ng-show="main.editingKeyword" ng-submit="main.saveKeyword()">
+          <input class="edit-keyword" focus-if="main.editingKeyword" ng-model="main.newKeyword.name"></input>
+        </form>
+
+        <!-- Edit Keyword Link -->
+        <p class="subheader">
+          <a ng-hide="main.editingKeyword" ng-click="main.editKeyword()">Edit keyword</a>
+          <a ng-show="main.editingKeyword" ng-click="main.saveKeyword()">Save keyword</a>
+        </p>
+
       </div>
 
       <!-- Metadata Header -->
@@ -66,7 +79,7 @@
       <!-- Context Panel -->
       <div class="callout small-12 columns">
         <h3>Context</h3>
-        <p>{{ main.context.front }} <strong>{{ main.keyword.name }}</strong> {{ main.context.back }}</p>
+        <p>{{ main.context.text }}</p>
       </div>
 
       <!-- Definition Panel -->

--- a/mendel/angular/src/app/main/main.scss
+++ b/mendel/angular/src/app/main/main.scss
@@ -99,6 +99,10 @@
 
     h1 {
       margin-bottom: 0;
+
+      small {
+        font-size: 1.25rem;
+      }
     }
 
     // Input field when editing keyword

--- a/mendel/angular/src/app/main/main.scss
+++ b/mendel/angular/src/app/main/main.scss
@@ -97,6 +97,24 @@
     border-right: 2px solid $border-color;
     padding-top: 0.5rem;
 
+    h1 {
+      margin-bottom: 0;
+    }
+
+    // Input field when editing keyword
+    input.edit-keyword {
+      border: 0;
+      border-width: 0;
+      font-size: 3rem;
+      width: 100%;
+      padding: 0;
+      line-height: 1.4;
+
+      &:focus {
+        outline: none;
+      }
+    }
+
     &.empty-state {
       .material-icons {
         margin-top: 3rem;

--- a/mendel/models.py
+++ b/mendel/models.py
@@ -14,6 +14,13 @@ class Keyword(models.Model):
     def __unicode__(self):
         return self.name
 
+    def clean(self):
+        self.name = self.name.capitalize()
+
+    def save(self, *args, **kwargs):
+            self.full_clean()
+            return super(Keyword, self).save(*args, **kwargs)
+
     def definition(self):
         try:
             client = swagger.ApiClient(settings.WORDNIK_API_KEY, settings.WORDNIK_API_URL)

--- a/urls.py
+++ b/urls.py
@@ -16,6 +16,10 @@ class KeywordSerializer(serializers.ModelSerializer):
         model = Keyword
         fields = ('id', 'name', 'definition')
 
+    def create(self, validated_data):
+        instance, _ = Keyword.objects.get_or_create(**validated_data)
+        return instance
+
 class KeyViewSet(viewsets.ModelViewSet):
     queryset = Keyword.objects.all()
     serializer_class = KeywordSerializer


### PR DESCRIPTION
This feature adds the ability to edit the keyword on a context before selecting categories.

Classical example of the need for this feature is when the keyword given is something like "fire," but the user can tell from the context that the relevant term to tag is really "fire rated."
